### PR TITLE
Add Jenkins Automation to Accept Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,6 @@ hs_err_pid*
 /.idea/misc.xml
 /.idea/uiDesigner.xml
 /.idea/vcs.xml
+
+# local gradle stuff
+.gradle/

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation group: 'pw.chew', name: 'jda-chewtils-commons', version: '2.0-SNAPSHOT'
     implementation group: 'pw.chew', name: 'jda-chewtils-command', version: '2.0-SNAPSHOT'
     implementation group: 'org.spongepowered', name: 'configurate-gson', version: '4.1.2'
+    implementation group: 'io.github.cdancy', name: 'jenkins-rest', version: '1.0.2'
 }
 
 artifacts {

--- a/src/main/java/io/codemc/bot/CodeMCBot.java
+++ b/src/main/java/io/codemc/bot/CodeMCBot.java
@@ -21,6 +21,7 @@ package io.codemc.bot;
 import com.jagrosh.jdautilities.command.CommandClientBuilder;
 import io.codemc.bot.commands.*;
 import io.codemc.bot.config.ConfigHandler;
+import io.codemc.bot.jenkins.JenkinsAPI;
 import io.codemc.bot.listeners.ModalListener;
 import io.codemc.bot.menu.ApplicationMenu;
 import net.dv8tion.jda.api.JDABuilder;
@@ -37,6 +38,7 @@ public class CodeMCBot{
     
     private final Logger logger = LoggerFactory.getLogger(CodeMCBot.class);
     private final ConfigHandler configHandler = new ConfigHandler();
+    private final JenkinsAPI jenkins = new JenkinsAPI(this);
     
     public static void main(String[] args){
         try{
@@ -90,6 +92,13 @@ public class CodeMCBot{
             
             clientBuilder.setCoOwnerIds(coOwnerIds);
         }
+
+        logger.info("Pinging Jenkins...");
+        if(!jenkins.ping()){
+            logger.warn("Unable to ping Jenkins! Please check your configuration.");
+            System.exit(1);
+            return;
+        }
         
         logger.info("Adding commands...");
         clientBuilder.addSlashCommands(
@@ -105,7 +114,7 @@ public class CodeMCBot{
             new ApplicationMenu.Accept(this),
             new ApplicationMenu.Deny(this)
         );
-        
+
         logger.info("Starting bot...");
         JDABuilder.createDefault(token)
             .enableIntents(
@@ -124,8 +133,16 @@ public class CodeMCBot{
             )
             .build();
     }
+
+    public Logger getLogger(){
+        return logger;
+    }
     
     public ConfigHandler getConfigHandler(){
         return configHandler;
+    }
+
+    public JenkinsAPI getJenkins(){
+        return jenkins;
     }
 }

--- a/src/main/java/io/codemc/bot/commands/CmdApplication.java
+++ b/src/main/java/io/codemc/bot/commands/CmdApplication.java
@@ -124,7 +124,8 @@ public class CmdApplication extends BotCommand{
                     .send();
                 return;
             }
-            
+
+            String finalRepoLink = repoLink;
             channel.sendMessage(getMessage(bot, userId, userLink, repoLink, str, accepted)).queue(m -> {
                 ThreadChannel thread = message.getStartedThread();
                 if(thread != null && !thread.isArchived()){
@@ -164,7 +165,7 @@ public class CmdApplication extends BotCommand{
                     return;
                 }
 
-                boolean jobSuccess = bot.getJenkins().createJenkinsJob(username, project, repoLink, freestyle);
+                boolean jobSuccess = bot.getJenkins().createJenkinsJob(username, project, finalRepoLink, freestyle);
                 if (!jobSuccess) {
                     CommandUtil.EmbedReply.fromHook(hook)
                             .withError("Failed to create Jenkins job for " + username + "! Manual creation required.")

--- a/src/main/java/io/codemc/bot/commands/CmdApplication.java
+++ b/src/main/java/io/codemc/bot/commands/CmdApplication.java
@@ -164,7 +164,7 @@ public class CmdApplication extends BotCommand{
                     return;
                 }
 
-                boolean jobSuccess = bot.getJenkins().createJenkinsJob(username, project, freestyle);
+                boolean jobSuccess = bot.getJenkins().createJenkinsJob(username, project, repoLink, freestyle);
                 if (!jobSuccess) {
                     CommandUtil.EmbedReply.fromHook(hook)
                             .withError("Failed to create Jenkins job for " + username + "! Manual creation required.")

--- a/src/main/java/io/codemc/bot/commands/CmdApplication.java
+++ b/src/main/java/io/codemc/bot/commands/CmdApplication.java
@@ -142,9 +142,8 @@ public class CmdApplication extends BotCommand{
                     return;
                 }
 
-                String username = member.getEffectiveName();
-
                 String[] split = str.split("/");
+                String username = split[4];
                 String project = split[6];
 
                 boolean userSuccess = bot.getJenkins().createJenkinsUser(username);
@@ -229,7 +228,7 @@ public class CmdApplication extends BotCommand{
             
             this.options = Arrays.asList(
                 new OptionData(OptionType.STRING, "id", "The message id of the application.").setRequired(true),
-                new OptionData(OptionType.STRING, "project-url", "The URL of the newly made Project.").setRequired(true),
+                new OptionData(OptionType.STRING, "project-url", "The URL of the newly made Project. Their username should reflect their GitHub username, not their Discord username.").setRequired(true),
                 new OptionData(OptionType.BOOLEAN, "freestyle", "False if built with Maven. If built with something other than Maven (such as Gradle), set to true.").setRequired(true)
             );
         }

--- a/src/main/java/io/codemc/bot/jenkins/JenkinsAPI.java
+++ b/src/main/java/io/codemc/bot/jenkins/JenkinsAPI.java
@@ -105,6 +105,8 @@ public class JenkinsAPI {
         String template = isFreestyle ? jenkinsFreestyleJob() : jenkinsMavenJob();
         if (template == null) return false;
 
+        template = template.replace("{PROJECT_URL}", "https://github.com/" + username + "/" + jobName);
+
         // Jenkins will automatically add job to the URL
         RequestStatus status = client.api().jobsApi().create(username, jobName, template);
         return status.value();

--- a/src/main/java/io/codemc/bot/jenkins/JenkinsAPI.java
+++ b/src/main/java/io/codemc/bot/jenkins/JenkinsAPI.java
@@ -101,11 +101,11 @@ public class JenkinsAPI {
         return status.value();
     }
 
-    public boolean createJenkinsJob(String username, String jobName, boolean isFreestyle){
+    public boolean createJenkinsJob(String username, String jobName, String repoLink, boolean isFreestyle){
         String template = isFreestyle ? jenkinsFreestyleJob() : jenkinsMavenJob();
         if (template == null) return false;
 
-        template = template.replace("{PROJECT_URL}", "https://github.com/" + username + "/" + jobName);
+        template = template.replace("{PROJECT_URL}", repoLink);
 
         // Jenkins will automatically add job to the URL
         RequestStatus status = client.api().jobsApi().create(username, jobName, template);

--- a/src/main/java/io/codemc/bot/jenkins/JenkinsAPI.java
+++ b/src/main/java/io/codemc/bot/jenkins/JenkinsAPI.java
@@ -28,6 +28,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
 import java.util.stream.Collectors;
 
 public class JenkinsAPI {
@@ -71,15 +72,15 @@ public class JenkinsAPI {
         }
     }
 
-    public String jenkinsUserTemplate(){
+    private String jenkinsUserTemplate(){
         return template("/template-user-config.xml");
     }
 
-    public String jenkinsMavenJob(){
+    private String jenkinsMavenJob(){
         return template("/template-job-maven.xml");
     }
 
-    public String jenkinsFreestyleJob(){
+    private String jenkinsFreestyleJob(){
         return template("/template-job-freestyle.xml");
     }
 

--- a/src/main/java/io/codemc/bot/jenkins/JenkinsAPI.java
+++ b/src/main/java/io/codemc/bot/jenkins/JenkinsAPI.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2024 CodeMC.io
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all copies or substantial
+ * portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+ * OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package io.codemc.bot.jenkins;
+
+import com.cdancy.jenkins.rest.JenkinsClient;
+import com.cdancy.jenkins.rest.domain.common.RequestStatus;
+import com.cdancy.jenkins.rest.domain.system.SystemInfo;
+import io.codemc.bot.CodeMCBot;
+import io.codemc.bot.config.ConfigHandler;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.stream.Collectors;
+
+public class JenkinsAPI {
+
+    private final CodeMCBot bot;
+    private final JenkinsClient client;
+
+    public JenkinsAPI(CodeMCBot bot){
+        this.bot = bot;
+
+        ConfigHandler config = bot.getConfigHandler();
+        String url = config.getString("jenkins", "url");
+        String username = config.getString("jenkins", "username");
+        String token = config.getString("jenkins", "token");
+        this.client = JenkinsClient.builder()
+                .endPoint(url)
+                .credentials(username + ":" + token)
+                .build();
+    }
+
+    public boolean ping(){
+        SystemInfo info = client.api().systemApi().systemInfo();
+        return info != null;
+    }
+
+    // Templates
+
+    private String template(String path){
+        try(InputStream stream = CodeMCBot.class.getResourceAsStream(path)) {
+            if (stream == null) return null;
+            try (InputStreamReader isr = new InputStreamReader(stream)) {
+                BufferedReader reader = new BufferedReader(isr);
+                return reader.lines().collect(Collectors.joining(System.lineSeparator()));
+            } catch (IOException e) {
+                bot.getLogger().error("Error reading {}", path, e);
+                return null;
+            }
+        } catch (IOException e) {
+            bot.getLogger().error("Error finding {}", path, e);
+            return null;
+        }
+    }
+
+    public String jenkinsUserTemplate(){
+        return template("/template-user-config.xml");
+    }
+
+    public String jenkinsMavenJob(){
+        return template("/template-job-maven.xml");
+    }
+
+    public String jenkinsFreestyleJob(){
+        return template("/template-job-freestyle.xml");
+    }
+
+    // Functions
+
+    private String createJenkinsConfig(String username){
+        String template = jenkinsUserTemplate();
+        if (template == null) return null;
+
+        return template.replace("{USERNAME}", username);
+    }
+
+    public boolean createJenkinsUser(String username){
+        String config = createJenkinsConfig(username);
+        if (config == null) return false;
+
+        RequestStatus status = client.api().jobsApi().create("/", username, config);
+        return status.value();
+    }
+
+    public boolean createJenkinsJob(String username, String jobName, boolean isFreestyle){
+        String template = isFreestyle ? jenkinsFreestyleJob() : jenkinsMavenJob();
+        if (template == null) return false;
+
+        // Jenkins will automatically add job to the URL
+        RequestStatus status = client.api().jobsApi().create(username, jobName, template);
+        return status.value();
+    }
+
+}

--- a/src/main/resources/config.json
+++ b/src/main/resources/config.json
@@ -20,5 +20,10 @@
   "messages": {
     "accepted": [],
     "denied": []
+  },
+  "jenkins": {
+    "url": "URL",
+    "username": "USERNAME",
+    "token": "API TOKEN"
   }
 }

--- a/src/main/resources/config.json.sample
+++ b/src/main/resources/config.json.sample
@@ -43,5 +43,10 @@
       "",
       "You may re-apply unless mentioned otherwise in the Reason."
     ]
+  },
+  "jenkins": {
+    "url": "https://ci.codemc.io",
+    "username": "admin",
+    "token": "admin_api_token"
   }
 }

--- a/src/main/resources/template-job-freestyle.xml
+++ b/src/main/resources/template-job-freestyle.xml
@@ -1,0 +1,23 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<project>
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty plugin="gitlab-plugin@1.8.1">
+            <gitLabConnection/>
+            <jobCredentialId/>
+            <useAlternativeCredential>false</useAlternativeCredential>
+        </com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders/>
+    <publishers/>
+    <buildWrappers/>
+</project>

--- a/src/main/resources/template-job-freestyle.xml
+++ b/src/main/resources/template-job-freestyle.xml
@@ -4,20 +4,55 @@
     <description/>
     <keepDependencies>false</keepDependencies>
     <properties>
+        <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.39.0">
+            <projectUrl>{PROJECT_URL}</projectUrl>
+            <displayName/>
+        </com.coravy.hudson.plugins.github.GithubProjectProperty>
         <com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty plugin="gitlab-plugin@1.8.1">
             <gitLabConnection/>
             <jobCredentialId/>
             <useAlternativeCredential>false</useAlternativeCredential>
         </com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty>
     </properties>
-    <scm class="hudson.scm.NullSCM"/>
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.2">
+        <configVersion>2</configVersion>
+        <userRemoteConfigs>
+            <hudson.plugins.git.UserRemoteConfig>
+                <url>{PROJECT_URL}</url>
+            </hudson.plugins.git.UserRemoteConfig>
+        </userRemoteConfigs>
+        <branches>
+            <hudson.plugins.git.BranchSpec>
+                <name>*/master</name>
+            </hudson.plugins.git.BranchSpec>
+        </branches>
+        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+        <submoduleCfg class="empty-list"/>
+        <extensions/>
+    </scm>
     <canRoam>true</canRoam>
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers/>
+    <jdk>(System)</jdk>
+    <triggers>
+        <hudson.triggers.SCMTrigger>
+            <spec>H/15 * * * *</spec>
+            <ignorePostCommitHooks>false</ignorePostCommitHooks>
+        </hudson.triggers.SCMTrigger>
+    </triggers>
     <concurrentBuild>false</concurrentBuild>
     <builders/>
-    <publishers/>
+    <publishers>
+        <hudson.tasks.ArtifactArchiver>
+            <artifacts>**/build/libs/*.jar</artifacts>
+            <allowEmptyArchive>false</allowEmptyArchive>
+            <onlyIfSuccessful>false</onlyIfSuccessful>
+            <fingerprint>false</fingerprint>
+            <defaultExcludes>true</defaultExcludes>
+            <caseSensitive>true</caseSensitive>
+            <followSymlinks>false</followSymlinks>
+        </hudson.tasks.ArtifactArchiver>
+    </publishers>
     <buildWrappers/>
 </project>

--- a/src/main/resources/template-job-maven.xml
+++ b/src/main/resources/template-job-maven.xml
@@ -1,14 +1,55 @@
 <?xml version='1.1' encoding='UTF-8'?>
 <maven2-moduleset plugin="maven-plugin@3.23">
     <keepDependencies>false</keepDependencies>
-    <properties/>
-    <scm class="hudson.scm.NullSCM"/>
+    <properties>
+        <jenkins.plugins.maveninfo.config.MavenInfoJobConfig plugin="maven-info@0.3.1">
+            <mainModulePattern/>
+            <dependenciesPattern/>
+            <assignName>false</assignName>
+            <nameTemplate/>
+            <assignDescription>false</assignDescription>
+            <descriptionTemplate/>
+        </jenkins.plugins.maveninfo.config.MavenInfoJobConfig>
+        <com.coravy.hudson.plugins.github.GithubProjectProperty plugin="github@1.39.0">
+            <projectUrl>{PROJECT_URL}</projectUrl>
+            <displayName/>
+        </com.coravy.hudson.plugins.github.GithubProjectProperty>
+        <com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty plugin="gitlab-plugin@1.8.1">
+            <gitLabConnection/>
+            <jobCredentialId/>
+            <useAlternativeCredential>false</useAlternativeCredential>
+        </com.dabsquared.gitlabjenkins.connection.GitLabConnectionProperty>
+    </properties>
+    <scm class="hudson.plugins.git.GitSCM" plugin="git@5.2.2">
+        <configVersion>2</configVersion>
+        <userRemoteConfigs>
+            <hudson.plugins.git.UserRemoteConfig>
+                <url>{PROJECT_URL}</url>
+            </hudson.plugins.git.UserRemoteConfig>
+        </userRemoteConfigs>
+        <branches>
+            <hudson.plugins.git.BranchSpec>
+                <name>*/master</name>
+            </hudson.plugins.git.BranchSpec>
+        </branches>
+        <doGenerateSubmoduleConfigurations>false</doGenerateSubmoduleConfigurations>
+        <submoduleCfg class="empty-list"/>
+        <extensions/>
+    </scm>
     <canRoam>true</canRoam>
     <disabled>false</disabled>
     <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
     <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
-    <triggers/>
+    <jdk>(System)</jdk>
+    <triggers>
+        <hudson.triggers.SCMTrigger>
+            <spec>H/15 * * * *</spec>
+            <ignorePostCommitHooks>false</ignorePostCommitHooks>
+        </hudson.triggers.SCMTrigger>
+    </triggers>
     <concurrentBuild>false</concurrentBuild>
+    <goals>clean package -B</goals>
+    <mavenName>Latest</mavenName>
     <aggregatorStyleBuild>true</aggregatorStyleBuild>
     <incrementalBuild>false</incrementalBuild>
     <ignoreUpstremChanges>false</ignoreUpstremChanges>
@@ -21,13 +62,31 @@
     <mavenValidationLevel>-1</mavenValidationLevel>
     <runHeadless>false</runHeadless>
     <disableTriggerDownstreamProjects>false</disableTriggerDownstreamProjects>
+    <blockTriggerWhenBuilding>true</blockTriggerWhenBuilding>
     <settings class="jenkins.mvn.DefaultSettingsProvider"/>
     <globalSettings class="org.jenkinsci.plugins.configfiles.maven.job.MvnGlobalSettingsProvider" plugin="config-file-provider@973.vb_a_80ecb_9a_4d0">
         <settingsConfigId>e5b005b5-be4d-4709-8657-1981662bcbe3</settingsConfigId>
     </globalSettings>
     <reporters/>
-    <publishers/>
+    <publishers>
+        <hudson.tasks.ArtifactArchiver>
+            <artifacts>**/target/*.jar</artifacts>
+            <excludes>**/original-*.jar</excludes>
+            <allowEmptyArchive>false</allowEmptyArchive>
+            <onlyIfSuccessful>false</onlyIfSuccessful>
+            <fingerprint>false</fingerprint>
+            <defaultExcludes>true</defaultExcludes>
+            <caseSensitive>true</caseSensitive>
+            <followSymlinks>false</followSymlinks>
+        </hudson.tasks.ArtifactArchiver>
+    </publishers>
     <buildWrappers/>
     <prebuilders/>
     <postbuilders/>
+    <runPostStepsIfResult>
+        <name>FAILURE</name>
+        <ordinal>2</ordinal>
+        <color>RED</color>
+        <completeBuild>true</completeBuild>
+    </runPostStepsIfResult>
 </maven2-moduleset>

--- a/src/main/resources/template-job-maven.xml
+++ b/src/main/resources/template-job-maven.xml
@@ -1,0 +1,33 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<maven2-moduleset plugin="maven-plugin@3.23">
+    <keepDependencies>false</keepDependencies>
+    <properties/>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <aggregatorStyleBuild>true</aggregatorStyleBuild>
+    <incrementalBuild>false</incrementalBuild>
+    <ignoreUpstremChanges>false</ignoreUpstremChanges>
+    <ignoreUnsuccessfulUpstreams>false</ignoreUnsuccessfulUpstreams>
+    <archivingDisabled>false</archivingDisabled>
+    <siteArchivingDisabled>false</siteArchivingDisabled>
+    <fingerprintingDisabled>false</fingerprintingDisabled>
+    <resolveDependencies>false</resolveDependencies>
+    <processPlugins>false</processPlugins>
+    <mavenValidationLevel>-1</mavenValidationLevel>
+    <runHeadless>false</runHeadless>
+    <disableTriggerDownstreamProjects>false</disableTriggerDownstreamProjects>
+    <settings class="jenkins.mvn.DefaultSettingsProvider"/>
+    <globalSettings class="org.jenkinsci.plugins.configfiles.maven.job.MvnGlobalSettingsProvider" plugin="config-file-provider@973.vb_a_80ecb_9a_4d0">
+        <settingsConfigId>e5b005b5-be4d-4709-8657-1981662bcbe3</settingsConfigId>
+    </globalSettings>
+    <reporters/>
+    <publishers/>
+    <buildWrappers/>
+    <prebuilders/>
+    <postbuilders/>
+</maven2-moduleset>

--- a/src/main/resources/template-user-config.xml
+++ b/src/main/resources/template-user-config.xml
@@ -1,0 +1,76 @@
+<?xml version='1.1' encoding='UTF-8'?>
+<com.cloudbees.hudson.plugins.folder.Folder plugin="cloudbees-folder@6.858.v898218f3609d">
+    <actions/>
+    <description/>
+    <properties>
+        <org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty plugin="config-file-provider@968.ve1ca_eb_913f8c">
+            <configs class="sorted-set">
+                <comparator class="org.jenkinsci.plugins.configfiles.ConfigByIdComparator"/>
+            </configs>
+        </org.jenkinsci.plugins.configfiles.folder.FolderConfigFileProperty>
+        <com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+            <inheritanceStrategy class="org.jenkinsci.plugins.matrixauth.inheritance.InheritParentStrategy"/>
+            <permission>USER:com.cloudbees.plugins.credentials.CredentialsProvider.Create:{USERNAME}</permission>
+            <permission>USER:com.cloudbees.plugins.credentials.CredentialsProvider.Delete:{USERNAME}</permission>
+            <permission>USER:com.cloudbees.plugins.credentials.CredentialsProvider.ManageDomains:{USERNAME}</permission>
+            <permission>USER:com.cloudbees.plugins.credentials.CredentialsProvider.Update:{USERNAME}</permission>
+            <permission>USER:com.cloudbees.plugins.credentials.CredentialsProvider.View:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Build:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Cancel:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Configure:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Create:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Delete:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Discover:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Move:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Read:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.ViewStatus:{USERNAME}</permission>
+            <permission>USER:hudson.model.Item.Workspace:{USERNAME}</permission>
+            <permission>USER:hudson.model.Run.Delete:{USERNAME}</permission>
+            <permission>USER:hudson.model.Run.Replay:{USERNAME}</permission>
+            <permission>USER:hudson.model.Run.Update:{USERNAME}</permission>
+            <permission>USER:hudson.model.View.Configure:{USERNAME}</permission>
+            <permission>USER:hudson.model.View.Create:{USERNAME}</permission>
+            <permission>USER:hudson.model.View.Delete:{USERNAME}</permission>
+            <permission>USER:hudson.model.View.Read:{USERNAME}</permission>
+            <permission>USER:hudson.plugins.promoted_builds.Promotion.Promote:{USERNAME}</permission>
+            <permission>USER:hudson.scm.SCM.Tag:{USERNAME}</permission>
+        </com.cloudbees.hudson.plugins.folder.properties.AuthorizationMatrixProperty>
+        <com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty>
+            <domainCredentialsMap class="hudson.util.CopyOnWriteMap$Hash">
+                <entry>
+                    <com.cloudbees.plugins.credentials.domains.Domain plugin="credentials@1337.v60b_d7b_c7b_c9f">
+                        <specifications/>
+                    </com.cloudbees.plugins.credentials.domains.Domain>
+                    <java.util.concurrent.CopyOnWriteArrayList/>
+                </entry>
+            </domainCredentialsMap>
+        </com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider_-FolderCredentialsProperty>
+        <org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig plugin="docker-workflow@572.v950f58993843">
+            <dockerLabel/>
+            <registry plugin="docker-commons@439.va_3cb_0a_6a_fb_29"/>
+        </org.jenkinsci.plugins.docker.workflow.declarative.FolderConfig>
+        <org.jenkinsci.plugins.pipeline.maven.MavenConfigFolderOverrideProperty plugin="pipeline-maven@1376.v18876d10ce9c">
+            <settings class="jenkins.mvn.DefaultSettingsProvider"/>
+            <globalSettings class="jenkins.mvn.DefaultGlobalSettingsProvider"/>
+            <override>false</override>
+        </org.jenkinsci.plugins.pipeline.maven.MavenConfigFolderOverrideProperty>
+    </properties>
+    <folderViews class="com.cloudbees.hudson.plugins.folder.views.DefaultFolderViewHolder">
+        <views>
+            <hudson.model.AllView>
+                <owner class="com.cloudbees.hudson.plugins.folder.Folder" reference="../../../.."/>
+                <name>All</name>
+                <filterExecutors>false</filterExecutors>
+                <filterQueue>false</filterQueue>
+                <properties class="hudson.model.View$PropertyList"/>
+            </hudson.model.AllView>
+        </views>
+        <tabBar class="hudson.views.DefaultViewsTabBar"/>
+    </folderViews>
+    <healthMetrics>
+        <com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+            <nonRecursive>false</nonRecursive>
+        </com.cloudbees.hudson.plugins.folder.health.WorstChildHealthMetric>
+    </healthMetrics>
+    <icon class="com.cloudbees.hudson.plugins.folder.icons.StockFolderIcon"/>
+</com.cloudbees.hudson.plugins.folder.Folder>


### PR DESCRIPTION
Depends on #1 being merged.

This PR uses the [jenkins-rest](https://github.com/cdancy/jenkins-rest) Java API to create a user and the job they were accepted with. The API requests a generated `config.xml`, for which I have added templates in the resources folders.

The Java Documentation is outdated and lacks JavaDoc comments, so I mostly went off the [REST API Documentation](https://ci.codemc.io/api/). I've tested the various parsing methods, but it should be tested on the CodeMC Beta bot with actual dummy parameters.

## Important Note
The GitHub OAuth plugin will hook into whatever username matches their **GitHub Profile**. The username and project name are based on the URL the reviewer provides (e.g. `https://ci.codemc.io/job/gmitch215/job/MobChip`).

## Other Notes
- The templates are based on my [`config.xml`](https://ci.codemc.io/job/gmitch215/config.xml) and a `config.xml` from a blank project.
- There is a new `jenkins` section in the config.
  - `url`: The Jenkins URL ([https://ci.codemc.io](https://ci.codemc.io))
  - `username`: A Jenkins Username to identify the bot
  - `token`: An API Token with necessary permissions (can also be a GitHub access token from an admin)
- This adds a `freestyle` boolean parameter to the accept command that reviewers will need to input depending on the type of project. The description says that "freestyle" is defined as a *non-maven* project, similar to what the docs specify in making a new project.