### PR TITLE
Add modal to set reason for denying application.

### DIFF
--- a/src/main/java/io/codemc/bot/listeners/ButtonListener.java
+++ b/src/main/java/io/codemc/bot/listeners/ButtonListener.java
@@ -106,6 +106,7 @@ public class ButtonListener extends ListenerAdapter{
             TextInput reason = TextInput.create("reason", "Reason", TextInputStyle.PARAGRAPH)
                 .setPlaceholder("(Leave empty for no reason)")
                 .setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
+                .setRequired(false)
                 .build();
             
             Modal modal = Modal.create("deny_application:" + event.getMessageId(), "Deny Application")

--- a/src/main/java/io/codemc/bot/listeners/ButtonListener.java
+++ b/src/main/java/io/codemc/bot/listeners/ButtonListener.java
@@ -23,9 +23,14 @@ import io.codemc.bot.commands.CmdApplication;
 import io.codemc.bot.utils.CommandUtil;
 import net.dv8tion.jda.api.entities.Guild;
 import net.dv8tion.jda.api.entities.Member;
+import net.dv8tion.jda.api.entities.MessageEmbed;
 import net.dv8tion.jda.api.entities.Role;
 import net.dv8tion.jda.api.events.interaction.component.ButtonInteractionEvent;
 import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.components.ActionRow;
+import net.dv8tion.jda.api.interactions.components.text.TextInput;
+import net.dv8tion.jda.api.interactions.components.text.TextInputStyle;
+import net.dv8tion.jda.api.interactions.modals.Modal;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
@@ -98,9 +103,16 @@ public class ButtonListener extends ListenerAdapter{
                 return;
             }
             
-            event.deferReply(true).queue(
-                hook -> CmdApplication.handle(bot, hook, guild, event.getMessageIdLong(), "Reason not Provided", false)
-            );
+            TextInput reason = TextInput.create("reason", "Reason", TextInputStyle.PARAGRAPH)
+                .setPlaceholder("(Leave empty for no reason)")
+                .setMaxLength(MessageEmbed.VALUE_MAX_LENGTH)
+                .build();
+            
+            Modal modal = Modal.create("deny_application:" + event.getMessageId(), "Deny Application")
+                .addComponents(ActionRow.of(reason))
+                .build();
+            
+            event.replyModal(modal).queue();
         }
     }
     

--- a/src/main/java/io/codemc/bot/utils/CommandUtil.java
+++ b/src/main/java/io/codemc/bot/utils/CommandUtil.java
@@ -92,7 +92,7 @@ public class CommandUtil{
                 modalEvent.replyEmbeds(builder.build()).setEphemeral(true).queue();
             }else
             if(type instanceof ButtonInteractionEvent buttonEvent){
-                buttonEvent.replyEmbeds(builder.build()).queue();
+                buttonEvent.replyEmbeds(builder.build()).setEphemeral(true).queue();
             }else
             if(type instanceof InteractionHook hook){
                 hook.editOriginal(EmbedBuilder.ZERO_WIDTH_SPACE).setEmbeds(builder.build()).queue();


### PR DESCRIPTION
Makes the Deny button open a modal where an optional reason can be set.
Not providing any will instead set `*No reason provided*`

Also fixes an oversight where `EmbedReply` would set non-ephemeral messages for button interactions, causing possible spam by people trying to use a button they have no perms for.

Finally, some small improvements regarding username checks for submit modal to ensure the username is actually checked before sending it to the jenkins api (Removes IJ nagging about possibly-null issues)

Closes #17 